### PR TITLE
Use `#minus` instead of hypen `-` for luminosity label

### DIFF
--- a/tdrstyle.py
+++ b/tdrstyle.py
@@ -7,7 +7,7 @@ import ROOT as rt
 from array import array
 rt.gROOT.SetBatch(rt.kTRUE)
 
-cms_lumi = 'Run 2, 138 fb^{-1}'
+cms_lumi = 'Run 2, 138 fb^{#minus1}'
 cms_energy = '13'
 
 
@@ -19,7 +19,7 @@ def SetLumi(lumi, round_lumi=False):
     global cms_lumi
     if lumi!='':
         cms_lumi = f"{lumi:.0f}" if round_lumi else f"{lumi}"
-        cms_lumi += " fb^{-1}"
+        cms_lumi += " fb^{#minus1}"
     else:
         cms_lumi = lumi
 


### PR DESCRIPTION
Using `#minus` in ROOT because `-` would just be a short hyphen.

Note that the guidelines recommends `#font[122]{\55}`, but `#minus` is more convenient, human readable, and native to ROOT. https://twiki.cern.ch/twiki/bin/viewauth/CMS/Internal/PubGuidelines Maybe we can suggest to PubComm to recommend `#minus` instead?

Below are screenshots from the PDF output:

Before, with hyphen `-`:
<img width="549" alt="277685319-8904d22f-0eb9-4135-a2bf-d9ba2dfd0145" src="https://github.com/cms-cat/cms-root-style/assets/13318254/0731cf1e-2652-442b-a907-9eb7e6e54630">

After, with the bit longer `#minus`:
<img width="550" alt="277685278-f8228e23-0b7f-4b03-9d34-6c174f3846d2" src="https://github.com/cms-cat/cms-root-style/assets/13318254/4e16d985-2b06-4166-91f6-700ca6a9d724">

And just for the record, this is with `#font[122]{\55}`, which seems to be a bit shorter, and also raises the superscript a bit?
<img width="550" alt="277695621-3df01943-9a70-4c1e-aa1e-60a369b22095" src="https://github.com/cms-cat/cms-root-style/assets/13318254/ce938e89-c810-4b4b-b3cf-d0e5d2acce3f">
